### PR TITLE
fix for asm related error

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -33,7 +33,7 @@ zopen_append_to_env()
 cat <<ZZ
 if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
   export ZOPEN_EXTRA_CPPFLAGS="\${ZOPEN_EXTRA_CPPFLAGS} -DZOSLIB_OVERRIDE_CLIB=1"
-  export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -I\$PWD/include"
+  export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -fgnu-keywords -I\$PWD/include"
   export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -I\$PWD/include"
   export ZOPEN_EXTRA_LDFLAGS="\${ZOPEN_EXTRA_LDFLAGS} -L\$PWD/lib"
   export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lzoslib \$PWD/lib/CXXRT64.x"


### PR DESCRIPTION
I was getting following error in coreutils while building the port using clang compiler :
checking whether we are cross compiling
    configure:5917: xlclang -o conftest -qascii -std=gnu11 -qnocsect -qenum=int -qgonumber -O3 -qnose -std=c11 -I/home/haritha/code/m4port/m4-1.4.19/lib,/home/haritha/code/m4port/patches/PR1/include,/usr/include/le -I/home/haritha/zopen-data/prod/zoslib-zopen/include -DNSIG=42 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE -D_OPEN_SYS_FILE_EXT=1 -D_AE_BIMODAL=1 -D_ENHANCED_ASCII_EXT=0xFFFFFFFF  -DZOSLIB_OVERRIDE_CLIB=1 -Wl,edit=no  -L/home/haritha/zopen-data/prod/zoslib-zopen/lib conftest.c  -lzoslib /home/haritha/zopen-data/prod/zoslib-zopen/lib/CXXRT64.x >&5
    In file included from ./conftest.c:11:
    /home/haritha/zopen-data/prod/zoslib-zopen/include/stdio.h:41:71: error: expected function body after function declarator
    __Z_EXPORT extern FILE *fopen(const char *filename, const char *mode) asm("__fopen_ascii");
                                                                          ^
    ./conftest.c:15:11: warning: implicit declaration of function 'fopen' is invalid in C99 [-Wimplicit-function-declaration]
    FILE *f = fopen ("conftest.out", "w");
              ^
    ./conftest.c:15:7: warning: incompatible integer to pointer conversion initializing 'FILE *' (aka 'struct __ffile *') with an expression of type 'int' [-Wint-conversion]
    FILE *f = fopen ("conftest.out", "w");
          ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
    2 warnings and 1 error generated.
    Error while processing ./conftest.c.
    CCN0793(I) Compilation failed for file ./conftest.c.  Object file not created.
    configure:5921: $? = 12
    configure:5928: ./conftest
    ./conftest: eval: ./configure 5930: FSUM7351 not found
    configure:5932: $? = 127
    configure:5939: error: in `/home/haritha/code/m4port/m4-1.4.19':


On adding the above fix, the issue is resolved