### PR TITLE
Set up build to support clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 install/
 log/
 zoslib/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+install/
+log/
+zoslib/

--- a/buildenv
+++ b/buildenv
@@ -40,16 +40,16 @@ zopen_check_results()
 
 zopen_append_to_env()
 {
+  if [[ "$ZOPEN_COMP" == "XL" ]]; then
+    extra_libs="\$PWD/lib/CXXRT64.x"
+  fi
 cat <<ZZ
 if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
   export ZOPEN_EXTRA_CPPFLAGS="\${ZOPEN_EXTRA_CPPFLAGS} -DZOSLIB_OVERRIDE_CLIB=1"
   export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -isystem \$PWD/include"
   export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -isystem \$PWD/include"
   export ZOPEN_EXTRA_LDFLAGS="\${ZOPEN_EXTRA_LDFLAGS} -L\$PWD/lib"
-  export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lzoslib"
-  if [[ "$ZOPEN_COMP" == "XL" ]]; then
-    export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} \$PWD/lib/CXXRT64.x"
-  fi
+  export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lzoslib \$PWD/lib/celquopt.s.o $extra_libs"
 fi
 ZZ
 }

--- a/buildenv
+++ b/buildenv
@@ -1,11 +1,11 @@
 export ZOPEN_GIT_URL="https://github.com/ibmruntimes/zoslib.git"
-export ZOPEN_GIT_DEPS="git make cmake"
+export ZOPEN_GIT_DEPS="make cmake git"
 export ZOPEN_GIT_BRANCH="zopen"
 export ZOPEN_TYPE="GIT"
 
 export ZOPEN_CONFIGURE="cmake"
 export ZOPEN_CONFIGURE_OPTS=". -DBUILD_TESTING=ON -DENABLE_STATIC_INIT=ON -DZOSLIB_GENERIC=ON -DCMAKE_INSTALL_PREFIX=\$ZOPEN_INSTALL_DIR/ -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
-export ZOPEN_CONFIGURE_MINIMAL="yes"
+export ZOPEN_MAKE_MINIMAL="yes"
 
 export LIBPATH="\$PWD/lib/:\$LIBPATH"
 export ZOPEN_CHECK="./test/cctest_a"
@@ -32,10 +32,13 @@ zopen_append_to_env()
 {
 cat <<ZZ
 export ZOPEN_EXTRA_CPPFLAGS="\${ZOPEN_EXTRA_CPPFLAGS} -DZOSLIB_OVERRIDE_CLIB=1"
-export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -I\$PWD/include"
-export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -I\$PWD/include"
+export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -isystem \$PWD/include"
+export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -isystem \$PWD/include"
 export ZOPEN_EXTRA_LDFLAGS="\${ZOPEN_EXTRA_LDFLAGS} -L\$PWD/lib"
-export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lzoslib \$PWD/lib/CXXRT64.x"
+export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lzoslib"
+if [[ "$ZOPEN_COMP" == "XL" ]]; then
+  export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} \$PWD/lib/CXXRT64.x"
+fi
 ZZ
 }
 

--- a/buildenv
+++ b/buildenv
@@ -4,14 +4,24 @@ export ZOPEN_GIT_BRANCH="zopen"
 export ZOPEN_TYPE="GIT"
 
 export ZOPEN_CONFIGURE="cmake"
-export ZOPEN_CONFIGURE_OPTS=". -DBUILD_TESTING=ON -DENABLE_STATIC_INIT=ON -DZOSLIB_GENERIC=ON -DCMAKE_INSTALL_PREFIX=\$ZOPEN_INSTALL_DIR/ -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+export ZOPEN_CONFIGURE_OPTS="-B ../build  --install-prefix \$ZOPEN_INSTALL_DIR/ -DBUILD_TESTING=ON -DENABLE_STATIC_INIT=ON -DZOSLIB_GENERIC=ON -DCMAKE_INSTALL_PREFIX=\$ZOPEN_INSTALL_DIR/ -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ."
+
+export ZOPEN_MAKE="cmake"
+export ZOPEN_MAKE_OPTS=" --build ../build --target all"
 export ZOPEN_MAKE_MINIMAL="yes"
 
 export LIBPATH="\$PWD/lib/:\$LIBPATH"
-export ZOPEN_CHECK="./test/cctest_a"
+export ZOPEN_CHECK="../build/test/cctest_a"
 
 export ZOPEN_INSTALL="cmake"
-export ZOPEN_INSTALL_OPTS="--install . --prefix \$ZOPEN_INSTALL_DIR/"
+export ZOPEN_INSTALL_OPTS="--install ../build"
+
+export ZOPEN_CLEAN=zoslib_clean
+
+zoslib_clean()
+{
+  rm -rf ../build
+}
 
 zopen_check_results()
 {

--- a/buildenv
+++ b/buildenv
@@ -56,11 +56,14 @@ zopen_post_install()
   install_dir=$1
   # This is a nasty hack b/c zoslib uses C++ and many apps are C apps.
   # Those apps need to link with the c++ rt b/c zoslib has c++ code.
-  if [[ "$ZOPEN_COMP" == "XL" ]]; then
+  if [[ "$ZOPEN_COMP" == "XLCLANG" ]]; then
     libs=CXXRT64
     sceelib="CEE.SCEELIB"
   else
     libs="CRTDQCXA CRTDQCXE CRTDQCXP CRTDQCXS CRTDQUNW CRTDQXLA"
+    if [ ! -d "$TMPDIR" ]; then
+      TMPDIR=/tmp
+    fi
     tfn=$TMPDIR/empty.$$.o
     touch $tfn
     sceelib=$($CXX -### $TMPDIR/empty.$$.o 2>&1 |awk '{for (x=1; x<NF; x++) if ($x ~ /CRTDQUNW/) {sub(/^[^A-Z]*/,"",$x); sub(/\(.*/,"", $x); print $x; }}')

--- a/buildenv
+++ b/buildenv
@@ -47,7 +47,9 @@ ZZ
 zopen_post_install()
 {
   install_dir=$1
-  # Needed for C compiles since this library contains C++ runtime code
-  cat "//'CEE.SCEELIB(CXXRT64)'" | dd conv=block cbs=80 > "$install_dir/lib/CXXRT64.x"
-  chtag -tc 1047 "$install_dir/lib/CXXRT64.x"
+  if [[ "$ZOPEN_COMP" == "XL" ]]; then
+    # Needed for C compiles since this library contains C++ runtime code
+    cat "//'CEE.SCEELIB(CXXRT64)'" | dd conv=block cbs=80 > "$install_dir/lib/CXXRT64.x"
+    chtag -tc 1047 "$install_dir/lib/CXXRT64.x"
+  fi
 }

--- a/buildenv
+++ b/buildenv
@@ -40,16 +40,13 @@ zopen_check_results()
 
 zopen_append_to_env()
 {
-  if [[ "$ZOPEN_COMP" == "XL" ]]; then
-    extra_libs="\$PWD/lib/CXXRT64.x"
-  fi
 cat <<ZZ
 if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
   export ZOPEN_EXTRA_CPPFLAGS="\${ZOPEN_EXTRA_CPPFLAGS} -DZOSLIB_OVERRIDE_CLIB=1"
   export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -isystem \$PWD/include"
   export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -isystem \$PWD/include"
   export ZOPEN_EXTRA_LDFLAGS="\${ZOPEN_EXTRA_LDFLAGS} -L\$PWD/lib"
-  export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lzoslib \$PWD/lib/celquopt.s.o $extra_libs"
+  export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lzoslib \$PWD/lib/celquopt.s.o -lzoslib-supp"
 fi
 ZZ
 }
@@ -57,9 +54,28 @@ ZZ
 zopen_post_install()
 {
   install_dir=$1
+  # This is a nasty hack b/c zoslib uses C++ and many apps are C apps.
+  # Those apps need to link with the c++ rt b/c zoslib has c++ code.
   if [[ "$ZOPEN_COMP" == "XL" ]]; then
-    # Needed for C compiles since this library contains C++ runtime code
-    cat "//'CEE.SCEELIB(CXXRT64)'" | dd conv=block cbs=80 > "$install_dir/lib/CXXRT64.x"
-    chtag -tc 1047 "$install_dir/lib/CXXRT64.x"
+    libs=CXXRT64
+    sceelib="CEE.SCEELIB"
+  else
+    libs="CRTDQCXA CRTDQCXE CRTDQCXP CRTDQCXS CRTDQUNW CRTDQXLA"
+    tfn=$TMPDIR/empty.$$.o
+    touch $tfn
+    sceelib=$($CXX -### $TMPDIR/empty.$$.o 2>&1 |awk '{for (x=1; x<NF; x++) if ($x ~ /CRTDQUNW/) {sub(/^[^A-Z]*/,"",$x); sub(/\(.*/,"", $x); print $x; }}')
+    rm $tfn
   fi
+  (cd $install_dir/lib;
+  printf "%-80.80s" '*! IEWBIND INCLUDE' >side_deck_magic.x
+  rm -f libzoslib-supp.a
+  for l in ${libs}
+  do
+    cp -B "//'$sceelib($l)'" $l
+    cat side_deck_magic.x $l >$l.x
+    ar r $install_dir/lib/libzoslib-supp.a $l.x
+    rm $l $l.x
+  done
+  rm side_deck_magic.x
+  )
 }


### PR DESCRIPTION
1. Set up the buildenv to handle clang as well as xlclang
2. change the build so zoslib is built into a build subdir rather than the source dir