### PR TITLE
Build off of main branch rather than zopen

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,6 +1,6 @@
 export ZOPEN_GIT_URL="https://github.com/ibmruntimes/zoslib.git"
 export ZOPEN_GIT_DEPS="make cmake git coreutils"
-export ZOPEN_GIT_BRANCH="zopen"
+export ZOPEN_GIT_BRANCH="main"
 export ZOPEN_TYPE="GIT"
 export ZOPEN_DONT_ADD_ZOSLIB_DEP=1 # zoslib cannot currently build with itself
 


### PR DESCRIPTION
With https://github.com/ibmruntimes/zoslib/pull/36 now merged, we can build off of the main branch