### PR TITLE
No need for the thread_support copy with OEL 2.0.0.1

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -50,7 +50,7 @@ cat <<ZZ
 if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
   export ZOPEN_EXTRA_CPPFLAGS="\${ZOPEN_EXTRA_CPPFLAGS} -DZOSLIB_OVERRIDE_CLIB=1 -DZOSLIB_OVERRIDE_CLIB_GETENV=1"
   export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -isystem \$PWD/include"
-  export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -isystem \$PWD/include -isystem \$PWD/include/c++/v1"
+  export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -isystem \$PWD/include"
   export ZOPEN_EXTRA_LDFLAGS="\${ZOPEN_EXTRA_LDFLAGS} -L\$PWD/lib"
   export ZOPEN_EXTRA_LIBS="\${ZOPEN_EXTRA_LIBS} -lzoslib \$PWD/lib/celquopt.s.o -lzoslib-supp"
   if [[ "\$ZOPEN_COMP" == "XLCLANG" ]]; then


### PR DESCRIPTION
The latest ptf for OEL solves the nanosleep() problem.  I'm going to remove the copy of the `__thread_support` header added to zoslib.  We need to remove the -isystem so builds don't look for the copy of the header.  